### PR TITLE
New features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ used directly.
 * [Utility functions](#utility-functions)
   * [`toTransformer(fn)`](#totransformerfn)
 * [Transformers](#transformers)
-  * [`merge`](#merge)
+  * [`merge()`](#merge)
   * [`debounce(time)`](#debouncetime)
   * [`throttle(interval)`](#throttleinterval)
   * [`rebound(time, ...baseValues)`](#reboundtime-basevalues)
@@ -77,11 +77,12 @@ values and/or the flow of values through the pipe. These can either be simple
 transformers that are used as is, or transformer factories that can be
 configured via arguments.
 
-### `merge`
+### `merge()`
 
-This transformer merges incoming objects into a single object. This is a
-stateful transformer whose state persists throughout the life of the pipe in
-which it is used.
+Merge incoming objects into a single one.
+
+This is a stateful transformer whose state persists throughout the life of the
+pipe in which it is used.
 
 This transformer is usually used at the very start of a pipe in order to
 combine the inputs from several sources.
@@ -112,6 +113,8 @@ user.send({userId: 2}); // logs {"location":"/","userId":2}
 
 ### `debounce(time)`
 
+Debounce the flow of values.
+
 Debouncing is a common technique to limit the rate at which expensive code is
 exercised when faced with a high-trigger-rate event. Deboucing works by
 preventing the values from passing through until a specified period of calm is
@@ -141,6 +144,8 @@ document
 
 ### `throttle(interval)`
 
+Transformers that limits the flow of values to once in a specified interval.
+
 Throttle is a common technique to reduce the rate at which expensive code is
 exercised when faced with a high-trigger-rate event. Throttling achieves this
 by allowing values to pass through only at specified interval. If the time gap
@@ -163,6 +168,8 @@ window.addEventListener('scroll', parallaxPipe.send, false);
 ```
 
 ### `rebound(time, ...baseValues)`
+
+Send base value after a specified time after each transmitted value.
 
 This transformer reverts the pipe to base values with a specified delay after a
 value is received. Rebounding can be used for things that appear temporarily,
@@ -190,8 +197,7 @@ string after approximately five seconds.
 
 ### `filter(testFn)`
 
-This transformer will filter the value for which the test function returns a
-truthy value. 
+Filter values for which the test function returns truthy.
 
 Although this can be useful in a variety of creative ways, one of the users is
 to split a pipe into two branches. Here's an example of such usage:
@@ -214,6 +220,8 @@ p.send(false);
 ```
 
 ### `map(fn)`
+
+Apply a function to all values and transmit the return values.
 
 In many languages, there are functions that apply other functions to all values
 in a list or array or some other container type. The `map()` transformer serves
@@ -238,6 +246,8 @@ incPipe.send(1); // logs 2
 ```
 
 ### `reduce(fn, initialValue)`
+
+Reduce (collapse) incoming values to a single value according to a function.
 
 This transformer works similarly to `reduce()` in arrays, with the difference
 that there is no final value as pipes are a potentially never-ending stream of
@@ -268,6 +278,8 @@ document.addEventListener('click', counter.send, false);
 ```
 
 ### `get(path, defaultValue)`
+
+Get a value at specified path or return a default value if key is undefined.
 
 This transformer will take any object coming down the pipe and return a value
 that corresponds to the dot-separated path within the object. If such a path or

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "core-js": "2",
-    "transplexer": "^1.0.1"
+    "transplexer": "^1.1.0"
   },
   "files": [
     "dist"

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ export function get(path, defaultValue) {
   };
 };
 
-export function splitter(keys) {
+export function splitter(keys, ignoreMissingKeys = false) {
   let keyPipes = {}
 
   keys.forEach(function (key) {
@@ -152,6 +152,9 @@ export function splitter(keys) {
     ...keyPipes,
     send: function (obj) {
       keys.forEach(function (key) {
+        if (ignoreMissingKeys && !obj.hasOwnProperty(key)) {
+          return;
+        }
         keyPipes[key].send(obj[key]);
       });
     },

--- a/src/index.js
+++ b/src/index.js
@@ -180,9 +180,9 @@ export function sticky(initialValue) {
   };
 };
 
-export function junction(initialState) {
+export function junction(initialState, ...transformers) {
   let state = initialState || {};
-  let p = pipe();
+  let p = pipe(...transformers);
 
   return {
     sendAs: function (key) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,5 @@
 import pipe from 'transplexer';
 
-/**
- * Convert a function into a pipe transformer.
- *
- * This is a helper function that converts a normal function into a pipe
- * transformer. The function should take a value and return a value. The next
- * transformer is then invoked with the return value of the supplied function.
- *
- * Please note that this is not the only way to write transformers, and comes
- * with a limitation of not being able to avoid calling the next transformer.
- * If you want to write a transformers that sometimes wants to break the
- * transformer chain (e.g., debouncing/throttling), then you should write one
- * from scratch.
- */
 export function toTransformer(f) {
   return function (next) {
     return function (val) {
@@ -21,13 +8,6 @@ export function toTransformer(f) {
   };
 };
 
-/**
- * Transformer that maintains an object to which all values are merged
- *
- * The object this transformer maintains internally is mutable. Whenver a value
- * reaches this transformer, it will merge all own properties of the value into
- * the object, and transmit the object to the next transformer.
- */
 export function merge(next) {
   let obj = {};
 
@@ -37,14 +17,6 @@ export function merge(next) {
   };
 };
 
-/**
- * Transformer that debounces the flow of values
- *
- * When a value reaches this transformer, it delays transmission for a
- * specified period of time. The timer is reset every time a new value is
- * received. When the timer is allowed to run out, the last value received is
- * trasmitted. All values received before the last one will be discarded.
- */
 export function debounce(time) {
   return function (next) {
     let timer;
@@ -61,13 +33,6 @@ export function debounce(time) {
   };
 };
 
-/**
- * Transformers that limits the flow of values to a specified interval
- *
- * As values are received, they are allowed to go through only if the previous
- * value was received with a gap of at least the specified interval. If the gap
- * is less than the interval, then the value is discarded.
- */
 export function throttle(interval) {
   return function (next) {
     let lastCallTimestamp;
@@ -91,13 +56,6 @@ export function throttle(interval) {
   };
 };
 
-/**
- * Transformer that sends base values with a delay on every value received
- *
- * The time is specified in milliseconds. The base values defaults to no
- * values (connected callbacks or a transformer following this one are invoked
- * without arguments), and any number of values can be specified.
- */
 export function rebound(time, ...baseValues) {
   return function (next) {
     let timer;
@@ -114,15 +72,6 @@ export function rebound(time, ...baseValues) {
   };
 };
 
-/**
- * Transformer that filters values for which the test function returns truthy
- *
- * The return value of the `testFn` is only used for testing the values. When
- * this function returns a truthy vaule, the original value is passed on.
- *
- * The test function will receive all arguments that `send()` receives (that
- * is, whatever the previous transformer decides to relay).
- */
 export function filter(testFn) {
   return function (next) {
     return function (...args) {
@@ -133,12 +82,6 @@ export function filter(testFn) {
   };
 };
 
-/**
- * Transformer that applies a function to all values and passes on return value
- *
- * The function has to return a value, and the next transformer is invoked with
- * that value.
- */
 export function map(fn) {
   return function (next) {
     return function (...args) {
@@ -147,14 +90,6 @@ export function map(fn) {
   };
 };
 
-/**
- * Transformer that continually reduces incoming values into a single value
- *
- * The function `fn` takes the current state (or `initialValue` the first time)
- * and any number of arguments coming from the previous transformer or
- * `send()`, and must return the new state. The returned state is passed on to
- * the next transformer or connected callbacks.
- */
 export function reduce(fn, initialValue) {
   return function (next) {
     let state = initialValue;
@@ -166,9 +101,6 @@ export function reduce(fn, initialValue) {
   };
 };
 
-/**
- * Get a value at specified path or return a default value if key is undefined
- */
 export function get(path, defaultValue) {
   let segments = path.split('.');
 
@@ -212,23 +144,6 @@ export function get(path, defaultValue) {
   };
 };
 
-/**
- * Create an object that splits incoming objects into individual keys
- *
- * The only argument is an array of keys. For every key in the array, a pipe is
- * created and exposed through the key name in the return value of this
- * function. Because all specified keys become properties of the return value,
- * the `send` key cannot be used and will be omitted.
- *
- * Example:
- *
- *     let p = pipe();
- *     let s = splitter(['foo', 'bar']);
- *     p.connect(s.send);
- *     s.foo.connect(console.log);
- *     s.bar.connect(console.log);
- *
- */
 export function splitter(keys) {
   let keyPipes = {}
 
@@ -249,12 +164,6 @@ export function splitter(keys) {
   };
 };
 
-/**
- * Transformer that always emits the same value whenever any value is received
- *
- * The factory takes any number of arguments, and all arguments are passed on
- * to the next transformer.
- */
 export function always(...values) {
   return function (next) {
     return function () {
@@ -263,26 +172,6 @@ export function always(...values) {
   };
 };
 
-/**
- * Transformer that only passes on values if they are different to last one
- *
- * The `initialValue` argument seeds the initial value for comparison and is
- * `undefined` if unspecified.
- *
- * Values are compared for identity. This means that objects mutated in-place
- * will be treated as identical (because they are). The main use case for this
- * function is to handle primitive values right before they are use in DOM
- * mutations. For example:
- *
- *     let p = pipe(sticky(''));
- *     p.connect(function (text) {
- *       myDiv.textContent = text;
- *     });
- *
- *     p.send('');    // This will not alter the div
- *     p.send('foo'); // this updates the div
- *     p.send('foo'); // this does not update the div
- */
 export function sticky(initialValue) {
   return function (next) {
     return function (value) {
@@ -294,31 +183,6 @@ export function sticky(initialValue) {
   };
 };
 
-/**
- * Creates a stateful pipe junction
- *
- * The junction objects allow values coming from multiple pipes to be joined
- * into a single object where each pipe has its own key in the object. The
- * initial state of the object is specified as an argument to the `junction()`
- * function. If omitted, the initial state is an empty object.
- *
- * The junction object has a `send()` method which takes a key and returns a
- * callback to which pipes can connect. Values from the pipes connecting to
- * that callback will be placed under the specified key. For example:
- *
- *     import pipe from 'transplexer';
- *     import {junction} from 'transplexer-tools';
- *
- *     let j = junction();
- *     let p = pipe();
- *
- *     p.connect(j.sendAs('myKey'));
- *     j.connect(console.log);
- *
- *     p.send('test');
- *
- *     // logs '{myKey: 'test'}'
- */
 export function junction(initialState) {
   let state = initialState || {};
   let p = pipe();

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,6 @@
 import pipe from 'transplexer';
 
-export function toTransformer(f) {
-  return function (next) {
-    return function (val) {
-      next(f(val));
-    };
-  };
-};
+export const toTransformer = map;
 
 export function merge(next) {
   let obj = {};
@@ -174,10 +168,10 @@ export function always(...values) {
 
 export function sticky(initialValue) {
   return function (next) {
-    return function (value) {
+    return function (value, ...args) {
       if (value !== initialValue) {
         initialValue = value;
-        next(value);
+        next(value, ...args);
       }
     };
   };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -580,4 +580,24 @@ describe('junction', function () {
     expect(f).toHaveBeenCalledWith({foo: 'test', bar: 'nothing'});
   });
 
+  test('pass transformers to junction pipe', function () {
+    let f = jest.fn();
+    let p1 = pipe();
+    let p2 = pipe();
+    let j = junction({foo: 'nothing', bar: 'nothing'}, map(function (o) {
+      return {...o, baz: 'added by map'};
+    }));
+
+    p1.connect(j.sendAs('foo'));
+    p2.connect(j.sendAs('bar'));
+    j.connect(f);
+
+    p1.send('test');
+    expect(f).toHaveBeenCalledWith({
+      foo: 'test',
+      bar: 'nothing',
+      baz: 'added by map',
+    });
+  });
+
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,6 @@
 import * as fakeDate from 'jest-date-mock';
 import pipe from 'transplexer';
 import {
-  toTransformer,
   merge,
   debounce,
   throttle,
@@ -17,17 +16,6 @@ import {
 } from './index';
 
 jest.useFakeTimers();
-
-describe('toTransfromer', function () {
-
-  test('convert a pure function into a decorator', function () {
-    let c = jest.fn();
-    let deco = toTransformer(x => x + 1);
-    deco(c)(1);
-    expect(c).toHaveBeenCalledWith(2);
-  });
-
-});
 
 describe('merge', function () {
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -407,6 +407,36 @@ describe('splitter', function () {
     expect(barFn).toHaveBeenCalledWith('bar value');
   });
 
+  test('missing key will send undefined', function () {
+    let p = pipe();
+    let s = splitter(['foo', 'bar']);
+    let fooFn = jest.fn();
+    let barFn = jest.fn();
+    s.foo.connect(fooFn);
+    s.bar.connect(barFn);
+    p.connect(s.send);
+
+    p.send({foo: 'foo value'});
+
+    expect(fooFn).toHaveBeenCalledWith('foo value');
+    expect(barFn).toHaveBeenCalledWith(undefined);
+  });
+
+  test('suppress sending of missing keys', function () {
+    let p = pipe();
+    let s = splitter(['foo', 'bar'], true);
+    let fooFn = jest.fn();
+    let barFn = jest.fn();
+    s.foo.connect(fooFn);
+    s.bar.connect(barFn);
+    p.connect(s.send);
+
+    p.send({foo: 'foo value'});
+
+    expect(fooFn).toHaveBeenCalledWith('foo value');
+    expect(barFn).not.toHaveBeenCalled();
+  });
+
   test('send key is ignored', function () {
     let s = splitter(['send', 'bar']);
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -497,6 +497,33 @@ describe('sticky', function () {
     expect(f).toHaveBeenLastCalledWith(1);
   });
 
+  test('with additional values', function () {
+    let p = pipe(sticky(1));
+    let f = jest.fn();
+    p.connect(f);
+
+    p.send(2, 2, 2);
+    p.send(2, 2, 2);
+    p.send(3, 3, 3);
+
+    expect(f).toHaveBeenCalledTimes(2);
+    expect(f).toHaveBeenCalledWith(2, 2, 2);
+    expect(f).toHaveBeenCalledWith(3, 3, 3);
+  });
+
+  test('with additional values that change', function () {
+    let p = pipe(sticky(1));
+    let f = jest.fn();
+    p.connect(f);
+
+    p.send(2, 2, 2);
+    p.send(2, 3, 3);
+    p.send(3, 4, 4);
+
+    expect(f).toHaveBeenCalledTimes(2);
+    expect(f).toHaveBeenCalledWith(2, 2, 2);
+    expect(f).toHaveBeenCalledWith(3, 4, 4);
+  });
 });
 
 describe('junction', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,10 +4039,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-transplexer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/transplexer/-/transplexer-1.0.1.tgz#397d0b9674fdfd1983678473091d1f942cbc5196"
-  integrity sha512-oIuTdMYMj/QAWNYfTegGX3SG8A6o4r8Lg0QQvKPPYMxMsGjTHVHmN+3Gf5utRB3wfKRr6047/JoX9kjYQvryOA==
+transplexer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/transplexer/-/transplexer-1.1.0.tgz#de162346ab2ab478e04398c2a83a5d0bae16d4b6"
+  integrity sha512-9/DLLKEdIs7/1lyZF/PchlpIc6jUimv4rF2DD2A5aqB1JtILyUbp5pgearzBQjxFSUTeEOKR9rWg9oyp9tbfYA==
   dependencies:
     core-js "2"
 


### PR DESCRIPTION
- Updated to transplexer 1.1.0
- Added support for additional multiple values in `sticky()`
- Added ability to ignore missing keys in `splitter()`
- Added support for transformers in `junction()`
- Documentation cleaned up and improved
- Deprecated `toTransformer()`